### PR TITLE
Fix bug: open README.md raises UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import re
 
 from setuptools import setup
+from io import open
 
 with open("w3c_validator/__init__.py", "r") as f:
     VERSION = next(re.finditer("__version__ = \"(.*?)\"", f.read())).group(1).strip()
@@ -18,7 +19,7 @@ setup(
         "w3c_validator",
     ],
     license="MIT",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding='utf8').read(),
     install_requires=[
         "requests",
     ],


### PR DESCRIPTION
The file `README.md` contains non-ascii characters. While the builtin `open` function handles the `encoding` argument, this only happens in python3, and to support python2 (I don't known whether that is a concern of the author!) we need to import the `io.open` function.